### PR TITLE
G92 4-axis fix and Mac/Linux build error

### DIFF
--- a/GCV-3.6.1-T4/src/gcode.cpp
+++ b/GCV-3.6.1-T4/src/gcode.cpp
@@ -182,7 +182,7 @@ void GCode::grblSetHome()
     QString  sethome("G92 x0 y0 z0 ");
     if (numaxis == MAX_AXIS_COUNT)
 /// T4
-       sethome.append(QString(controlParams.fourthAxisName)).toLower().append("0");
+       sethome.append(QString(controlParams.fourthAxisName).toLower()).append("0");
 
     gotoXYZFourth(sethome);
 }

--- a/GCV-3.6.1-T4/src/mainwindow.h
+++ b/GCV-3.6.1-T4/src/mainwindow.h
@@ -27,7 +27,7 @@
 #include "positem.h"
 #include "gcode.h"
 #include "renderarea.h"
-#include "visu3D\viewer3D.h"
+#include "visu3D/viewer3D.h"
 
 #define COMPANY_NAME "zapmaker"
 #define APPLICATION_NAME "GrblController"


### PR DESCRIPTION
1. Replaced backslash with POSIX-style slash for directory separator in include.
2. G92 T axis value missing offset in 4-axis mode in GCV
   
   When clicking on the zero-axes button (to the right of the Home
   button), a G92 command of the form
   
     G92 x0 y0 z0 a
   
   would be incorrectly emitted.  This change moves the toLower() method
   so that it is called on the QString instance of the axis name
   attribute directly rather than on the result of the append() method.
