### PR TITLE
Linux bld fails with libQGLViewer2 and file case

### DIFF
--- a/GCV-3.6.1-T4/src/GCV.pro
+++ b/GCV-3.6.1-T4/src/GCV.pro
@@ -44,7 +44,14 @@ else {
 # QGlViewer
 QT += xml opengl
 INCLUDEPATH += QGLViewer QGLWidget
-LIBS += -lQGlViewer2
+unix {
+    LIBS += -lQGLViewer
+} else {
+    LIBS += -lQGlViewer2
+}
+unix:!macx {
+    LIBS += -lGLU
+}
 HEADER +=  visu3D/Point3D.h visu3D/Line3D.h visu3D/Arc3D.h visu3D/Tools3D.h  visu3D/Box3D.h
 SOURCES += visu3D/Point3D.cpp visu3D/Line3D.cpp visu3D/Arc3D.cpp visu3D/Tools3D.cpp visu3D/Box3D.cpp
 

--- a/GCV-3.6.1-T4/src/visu3D/viewer3D.cpp
+++ b/GCV-3.6.1-T4/src/visu3D/viewer3D.cpp
@@ -9,9 +9,9 @@
 
 #include "viewer3D.h"
 #include <math.h>
-#include "point3D.h"
-#include "line3D.h"
-#include "arc3d.h"
+#include "Point3D.h"
+#include "Line3D.h"
+#include "Arc3D.h"
 #include "box3D.h"
 #include "version.h"
 


### PR DESCRIPTION
According to http://www.libqglviewer.com/compilation.html the correct
spec for linking to libQGLViewer on Windows shows the trailing '2', but
not for Linux.  Also, the Linux build requires -lGLU (I presume that
the GL Utility library is bundled with the normal OpenGL libs on
Windows and Mac).

My previous pull request is also necessary.  This change avoids having
to make manual Makefile tweaks to the Makefile as well.  It also
corrects some filename case issues, as Linux's filesystems tend to be
case preserving and case sensitive.  (Mac is preserving, but not
sensitive, by default.)
